### PR TITLE
fixing sidebar resume icon

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -55,8 +55,8 @@
 		{% endif %}
 		{% if site.author.resume %}
 		<li>
-			<a class="btn btn-default btn-sm" href="{{ site.BASE_PATH }}/{{ site.rss_path }}">
-				<i class="fa fa-rss fa-lg"></i>
+			<a class="btn btn-default btn-sm" href="{{ site.BASE_PATH }}/{{ site.author.resume }}">
+				<i class="fa fa-file fa-lg"></i>
 			</a>
 		</li>
 		{% endif %}


### PR DESCRIPTION
I guess it should be either rss or resume. I went for resume and the fa-file icon in this case.
