### PR TITLE
Set the same width for all drop-down icons

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -80,11 +80,11 @@
 			<i class="fa fa-bars"></i>
 		</button>
 		<ul class="dropdown-menu" role="menu">
-			<li><a href="{{ site.BASE_PATH}}/"><i class="fa fa-home"></i> Home</a></li>
-			<li><a href="{{ site.BASE_PATH}}/{{ site.categories_path }}"><i class="fa fa-folder"></i> Categories</a></li>
-			<li><a href="{{ site.BASE_PATH}}/{{ site.tags_path }}"><i class="fa fa-tags"></i> Tags</a></li>
+			<li><a href="{{ site.BASE_PATH}}/"><i class="fa fa-home" style="width:1.3em"></i> Home</a></li>
+			<li><a href="{{ site.BASE_PATH}}/{{ site.categories_path }}"><i class="fa fa-folder" style="width:1.3em"></i> Categories</a></li>
+			<li><a href="{{ site.BASE_PATH}}/{{ site.tags_path }}"><i class="fa fa-tags" style="width:1.3em"></i> Tags</a></li>
 			<li class="divider"></li>
-			<li><a href="#"><i class="fa fa-arrow-up"></i> Top of Page</a></li>
+			<li><a href="#"><i class="fa fa-arrow-up" style="width:1.3em"></i> Top of Page</a></li>
 		</ul>
 	</div>
 


### PR DESCRIPTION
The original fa-tags is a little wider than other icons. This patch fixes this.
