### PR TITLE
Change highlighter attribute to pygments in config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 paginate: 10 # pagination based on number of posts
 paginate_path: "page:num"
 exclude: ["README.md"] # files to exclude
-highlighter: true
+highlighter: pygments
 markdown: kramdown
 
 


### PR DESCRIPTION
This should correctly highlight code syntax.
