### PR TITLE
Fix missing site.title property

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ highlighter: pygments
 markdown: kramdown
 disqus: dbyll
 google_analytics: dbyll
+title: dbyll
 
 defaults:
   -


### PR DESCRIPTION
Hello here!

`site.title` is important (see `_includes/default.html` and `_includes/sidebar.html`). See PR #15 to understand why `site.title` doesn't work anymore.

Example, before changes (desktop view) : 
![before-changes-desktop](https://cloud.githubusercontent.com/assets/10638479/13761688/84bd037c-ea3a-11e5-9dca-8c9ddc7e3375.png)

After changes : 

![after-changes-desktop](https://cloud.githubusercontent.com/assets/10638479/13761695/90096716-ea3a-11e5-8662-f38e07b5762b.png)

(responsive mode)
![after-changes-smartphone](https://cloud.githubusercontent.com/assets/10638479/13761697/929939fc-ea3a-11e5-8fb5-b3ff0f21cbaf.png)

`site.title` is different from `page.title` :) but both are important.