### PR TITLE
Fix typo: a missing ; on the line 46

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,7 +34,7 @@ a.nav-link {
 a.nav-link i{
 	font-size: 16px;
 }
-a.nav-link:hover { color: #777 }
+a.nav-link:hover { color: #777; }
 
 #bio {
 	font-family: "Courier New", Courier, monospace;


### PR DESCRIPTION
I think a `; `should be placed at this position. On ST3 + CSS3 pkg, the `bio` id selector which is follow right after it, has not been highlighted correctly.