### PR TITLE
Fix bug:sidebar background image will offset down

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -88,7 +88,7 @@
 		</ul>
 	</div>
 
-	<div class="col-sm-3 sidebar hidden-xs" style="{% if site.sidebar_background_image %}background: url({{site.sidebar_background_image}}) no-repeat center center !important;{% endif %}">
+	<div class="col-sm-3 sidebar hidden-xs" style="{% if site.sidebar_background_image %}background: url({{site.sidebar_background_image}}) no-repeat !important;{% endif %}">
 		{% include sidebar.html %}
 	</div>
 


### PR DESCRIPTION
Fix bug:When a document height exceeds the height of the sidebar background image, the background image will be Offset down