### PR TITLE
Setting siderbar styles fix for Edge

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,7 +2,7 @@
 
  function init() {
     /* Sidebar height set */
-    $sidebarStyles = $('.sidebar').attr('style')
+    $sidebarStyles = $('.sidebar').attr('style') || "";
     $sidebarStyles += ' min-height: ' + $(document).height() + 'px;';
     $('.sidebar').attr('style', $sidebarStyles);
 


### PR DESCRIPTION
Small fix for Edge browser - it seems that other browsers return "" for empty attribute when using " $('.sidebar').attr('style')" but Edge returns **undefined**. That is why inline style for sidebar is broken in Edge