### PR TITLE
Fix mixed content warnings from gravatar and fonts.googleapis

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -59,7 +59,7 @@
 			</a>
 			{% endif %}
 			<a class="navbar-brand" href="{{ site.BASE_PATH }}/">
-				<img src="http://www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
+				<img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
 				{{ site.title }}
 			</a>
 		</div>

--- a/_includes/default.html
+++ b/_includes/default.html
@@ -59,7 +59,7 @@
 			</a>
 			{% endif %}
 			<a class="navbar-brand" href="{{ site.BASE_PATH }}/">
-				<img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
+				<img src="//www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
 				{{ site.title }}
 			</a>
 		</div>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -92,7 +92,7 @@
       </section>
 
       <section class="col-sm-6 author">
-        <img src="http://www.gravatar.com/avatar/{{site.author.email_md5}}" class="img-rounded author-image" />
+        <img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}" class="img-rounded author-image" />
         <h4 class="section-title author-name">{{site.author.name}}</h4>
         <p class="author-bio">{{site.author.bio}}</p>
       </section>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -92,7 +92,7 @@
       </section>
 
       <section class="col-sm-6 author">
-        <img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}" class="img-rounded author-image" />
+        <img src="//www.gravatar.com/avatar/{{site.author.email_md5}}" class="img-rounded author-image" />
         <h4 class="section-title author-name">{{site.author.name}}</h4>
         <p class="author-bio">{{site.author.bio}}</p>
       </section>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <!-- sidebar.html -->
 <header class="sidebar-header" role="banner">
 	<a href="{{ site.BASE_PATH }}/">
-		<img src="http://www.gravatar.com/avatar/{{site.author.email_md5}}?s=150" class="img-circle" />
+		<img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}?s=150" class="img-circle" />
 	</a>
 	<h3 class="title">
         <a href="{{ site.BASE_PATH }}/">{{ site.title }}</a>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <!-- sidebar.html -->
 <header class="sidebar-header" role="banner">
 	<a href="{{ site.BASE_PATH }}/">
-		<img src="https://www.gravatar.com/avatar/{{site.author.email_md5}}?s=150" class="img-circle" />
+		<img src="//www.gravatar.com/avatar/{{site.author.email_md5}}?s=150" class="img-circle" />
 	</a>
 	<h3 class="title">
         <a href="{{ site.BASE_PATH }}/">{{ site.title }}</a>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Ubuntu:500&subset=latin,latin-ext);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu:500&subset=latin,latin-ext);
 
 body{
 	color: #2c3e50;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Ubuntu:500&subset=latin,latin-ext);
+@import url(//fonts.googleapis.com/css?family=Ubuntu:500&subset=latin,latin-ext);
 
 body{
 	color: #2c3e50;


### PR DESCRIPTION
Example mixed content warnings:

Mixed Content: The page at 'https://dbtek.github.io/dbyll/' was loaded
over HTTPS, but requested an insecure stylesheet
'http://dbtek.github.io/dbyll/assets/css/style.css'. This request has
been blocked; the content must be served over HTTPS.

Mixed Content: The page at 'https://dbtek.github.io/dbyll/' was loaded
over HTTPS, but requested an insecure image
'http://www.gravatar.com/avatar/726351295ec82e145928582f595aa3aa?s=35'.
This content should also be served over HTTPS.