### PR TITLE
Set BASE_PATH to just the path, no domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,4 +23,4 @@ rss_path: feed.xml
 categories_path: categories.html
 tags_path: tags.html
 
-BASE_PATH: http://dbtek.github.io/dbyll
+BASE_PATH: /dbyll


### PR DESCRIPTION
This should allow the HTTPS pages site to work too. See: https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/