### PR TITLE
Fix gems deprecation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,5 +36,5 @@ tags_path: tags.html
 
 BASE_PATH:
 
-gems:
+plugins:
   - jekyll-paginate


### PR DESCRIPTION
Hi,

This PR replace gems by plugins because of deprecation.

See https://github.com/jekyll/jekyll/pull/5130