### PR TITLE
Added fix for category and tag page for hosting under sub-domains

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,7 +18,8 @@
      * Tags & categories tab activation based on hash value. If hash is undefined then first tab is activated.
      */
     function activateTab() {
-      if(['/tags.html', '/categories.html'].indexOf(window.location.pathname) > -1) {
+      var path = window.location.pathname.split('/').pop();
+      if(['tags.html', 'categories.html'].indexOf(path) > -1) {
         var hash = window.location.hash;
         if(hash)
           $('.tab-pane').length && $('a[href="' + hash + '"]').tab('show');


### PR DESCRIPTION
Added a fix for the category and tag page for users hosting this page under a sub-domain. This had an issue before where the tab's of articles wouldn't load since it couldn't find the page type from the location pathname.